### PR TITLE
[#524] Added EasyIce to all components except nao* giraffeServer

### DIFF
--- a/src/drivers/MAVLinkServer/MAVLinkServer.py
+++ b/src/drivers/MAVLinkServer/MAVLinkServer.py
@@ -15,6 +15,7 @@ import select
 import shlex
 import math
 import Ice, jderobot
+import easyiceconfig as EasyIce
 
 from MAVProxy.modules.lib import textconsole
 from MAVProxy.modules.lib import rline
@@ -909,7 +910,7 @@ def openPose3DChannel(Pose3D):
     ic = None
     Pose2Tx = Pose3D #Pose3D.getPose3DData()
     try:
-        ic = Ice.initialize(sys.argv)
+        ic = EasyIce.initialize(sys.argv)
         adapter = ic.createObjectAdapterWithEndpoints("Pose3DAdapter", "default -p 9998")
         object = Pose2Tx
         #print object.getPose3DData()
@@ -935,7 +936,7 @@ def openCMDVelChannel(CMDVel):
     ic = None
     CMDVel2Rx = CMDVel #CMDVel.getCMDVelData()
     try:
-        ic = Ice.initialize(sys.argv)
+        ic = EasyIce.initialize(sys.argv)
         adapter = ic.createObjectAdapterWithEndpoints("CMDVelAdapter", "default -p 9999")
         object = CMDVel2Rx
         print CMDVel2Rx
@@ -971,7 +972,7 @@ def openNavdataChannel():
     Navdata2Tx = NavdataI()
 
     try:
-        ic = Ice.initialize(sys.argv)
+        ic = EasyIce.initialize(sys.argv)
         adapter = ic.createObjectAdapterWithEndpoints("NavdataAdapter", "default -p 9001")
         object = Navdata2Tx
         adapter.add(object, ic.stringToIdentity("Navdata"))
@@ -1000,7 +1001,7 @@ def openExtraChannel():
     ic = None
     Extra2Tx = ExtraI()
     try:
-        ic = Ice.initialize(sys.argv)
+        ic = EasyIce.initialize(sys.argv)
         adapter = ic.createObjectAdapterWithEndpoints("ExtraAdapter", "default -p 9002")
         object = Extra2Tx
         adapter.add(object, ic.stringToIdentity("Extra"))

--- a/src/drivers/ardrone_server/CMakeLists.txt
+++ b/src/drivers/ardrone_server/CMakeLists.txt
@@ -21,10 +21,12 @@ if(ARDRONE_ALL_DEPS)
 		${Boost_INCLUDE_DIR}
 		${EIGEN_INCLUDE_DIR}
 		${libxmlpp_INCLUDE_DIRS}
-		${ardronelib_INCLUDE_DIRS})
+		${ardronelib_INCLUDE_DIRS}
+    		${easyiceconfig_INCLUDE_DIRS})
 
 	link_directories(
-		${ardronelib_LIBRARY_DIRS})
+		${ardronelib_LIBRARY_DIRS}
+		${easyiceconfig_LIBRARY_DIRS})
 
 	include_directories(include)
 
@@ -54,6 +56,7 @@ if(ARDRONE_ALL_DEPS)
 	target_link_libraries(ardrone_server
 				${OpenCV_LIBRARIES}
 				${ZeroCIce_LIBRARIES}
+   				${easyiceconfig_LIBRARIES} 
 				colorspacesmm
 				JderobotInterfaces
 				${libxmlpp_LIBRARIES})
@@ -82,7 +85,8 @@ if(ARDRONE_ALL_DEPS)
 	target_link_libraries(ardrone_print_gps_data
 		${ZeroCIce_LIBRARIES}
 		ardrone_server_msgs
-		${CMAKE_THREAD_LIBS_INIT})
+		${CMAKE_THREAD_LIBS_INIT}
+    		${easyiceconfig_LIBRARIES})
 
 ELSE()
 	message(WARNING "ardrone_server marked to build, but required dependencies were not met.

--- a/src/drivers/ardrone_server/src/ardrone_driver.cpp
+++ b/src/drivers/ardrone_server/src/ardrone_driver.cpp
@@ -26,6 +26,7 @@
 #include "ardrone_server/interfaces/ardroneextrai.h"
 #include "ardrone_server/interfaces/navdatagpsi.h"
 #include <signal.h>
+#include "easyiceconfig/EasyIce.h" 
 
 
 ARDroneDriver::ARDroneDriver()
@@ -195,7 +196,7 @@ void ARDroneDriver::configureDrone(char* configFile)
 
 void ARDroneDriver::initIce(int argc, char** argv)
 {
-	ic = Ice::initialize(argc, argv);
+	ic = EasyIce::initialize(argc, argv);
 }
 
 Ice::CommunicatorPtr ARDroneDriver::getCommunicator()

--- a/src/drivers/ardrone_server/test/print_gps_data.cpp
+++ b/src/drivers/ardrone_server/test/print_gps_data.cpp
@@ -21,13 +21,14 @@
 #include <iostream>
 #include <boost/format.hpp>
 #include <Ice/Ice.h>
+#include "easyiceconfig/EasyIce.h"
 
 #include <navdatagps.h>
 
 void print_data(ardrone::NavdataGPSData data);
 
 int main(int argc, char* argv[]) {
-	Ice::CommunicatorPtr ic = Ice::initialize(argc, argv);
+	Ice::CommunicatorPtr ic = EasyIce::initialize(argc, argv);
 
 	//Ice::ObjectPrx prx = ic->propertyToProxy("ArDrone.NavdataGPS.Proxy");
 	Ice::ObjectPrx prx = ic->stringToProxy("ardrone_navdatagps:tcp -h 0.0.0.0 -p 9993");

--- a/src/drivers/basic_server/CMakeLists.txt
+++ b/src/drivers/basic_server/CMakeLists.txt
@@ -12,11 +12,18 @@ include_directories(
     ${INTERFACES_CPP_DIR}
     ${LIBS_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${easyiceconfig_INCLUDE_DIRS}
 )
+
+link_directories(
+	${easyiceconfig_LIBRARY_DIRS}
+)
+
 
 add_executable (basic_server  ${SOURCE_FILES})
 
 TARGET_LINK_LIBRARIES(basic_server
         ${CMAKE_THREAD_LIBS_INIT}
-	${ZeroCIce_LIBRARIES}    	
+	${ZeroCIce_LIBRARIES}  
+    	${easyiceconfig_LIBRARIES}   	
 )

--- a/src/drivers/basic_server/basic_server.cpp
+++ b/src/drivers/basic_server/basic_server.cpp
@@ -2,6 +2,7 @@
 #include <IceUtil/IceUtil.h>
 #include "myInterface.h"
 #include <signal.h>
+#include "easyiceconfig/EasyIce.h" 
 
 
 
@@ -95,7 +96,7 @@ int main(int argc, char** argv){
 	
 
 	try{
-			ic = Ice::initialize(argc,argv);
+			ic = EasyIce::initialize(argc,argv);
 			prop = ic->getProperties();
 	}
 	catch (const Ice::Exception& ex) {

--- a/src/drivers/kinect2server/CMakeLists.txt
+++ b/src/drivers/kinect2server/CMakeLists.txt
@@ -8,6 +8,7 @@ IF(LIBFREENECT_PATH)
 
     include_directories(
         ${INTERFACES_CPP_DIR}
+    	${easyiceconfig_INCLUDE_DIRS}
         ${LIBS_DIR}/ 
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/cameras
@@ -16,6 +17,10 @@ IF(LIBFREENECT_PATH)
         ${freenect2_INCLUDE_DIRS}
 /usr/local/include/libfreenect2/tinythread/
     )
+
+link_directories(
+	${easyiceconfig_LIBRARY_DIRS}
+)
 
     TARGET_LINK_LIBRARIES(kinect2Server
         ${CMAKE_THREAD_LIBS_INIT}
@@ -30,6 +35,7 @@ IF(LIBFREENECT_PATH)
         colorspacesmm
         JderobotInterfaces
         ${Boost_LIBRARIES}
+    	${easyiceconfig_LIBRARIES}
         ${LIBXML2_LIBRARIES}
         ${ZLIB_LIBRARIES}
         ${freenect2_LIBRARIES}

--- a/src/drivers/kinect2server/kinect2Server.cpp
+++ b/src/drivers/kinect2server/kinect2Server.cpp
@@ -25,6 +25,7 @@
 
 #include <Ice/Ice.h>
 #include <IceUtil/IceUtil.h>
+#include "easyiceconfig/EasyIce.h" 
 #include <jderobot/kinectleds.h>
 #include <jderobot/camera.h>
 #include <jderobot/pose3dmotors.h>
@@ -1031,7 +1032,7 @@ int main(int argc, char** argv){
 
 
 	try{
-			ic = Ice::initialize(argc,argv);
+			ic = EasyIce::initialize(argc,argv);
 			prop = ic->getProperties();
 	}
 	catch (const Ice::Exception& ex) {

--- a/src/drivers/kobuki_driver/CMakeLists.txt
+++ b/src/drivers/kobuki_driver/CMakeLists.txt
@@ -5,6 +5,7 @@ if (${kobuki_COMPILE})
         ${INTERFACES_CPP_DIR}
         ${LIBS_DIR}/
         ${CMAKE_CURRENT_SOURCE_DIR}
+    	${easyiceconfig_INCLUDE_DIRS}
     )
 
     add_executable( kobuki_driver  main.cpp kobukimanager.cpp kobukimanager.h thread_control.cpp thread_control.h
@@ -12,7 +13,10 @@ if (${kobuki_COMPILE})
                                    sensors/pose3d.h sensors/pose3d.cpp sensors/quaternion.h
     )
 			       
-    link_directories(${kobuki_LIBRARIES})
+    link_directories(
+	${kobuki_LIBRARIES}
+	${easyiceconfig_LIBRARY_DIRS}
+    )
     include_directories(${kobuki_INCLUDE_DIR})
 			       
     target_link_libraries(kobuki_driver
@@ -21,5 +25,6 @@ if (${kobuki_COMPILE})
         JderobotInterfaces
         jderobotutil
         ${ZeroCIce_LIBRARIES}
+    	${easyiceconfig_LIBRARIES} 
     )
 ENDIF()

--- a/src/drivers/kobuki_driver/main.cpp
+++ b/src/drivers/kobuki_driver/main.cpp
@@ -2,6 +2,8 @@
  Includes
  ****************************************************************************/
 #include "thread_control.h"
+#include "easyiceconfig/EasyIce.h" 
+
 
 /*****************************************************************************
  Signal Handler
@@ -26,7 +28,7 @@ int main(int argc, char** argv)
 
     try {
         //-----------------ICE----------------//
-        ic = Ice::initialize(argc, argv);
+        ic = EasyIce::initialize(argc, argv);
 
         Thread_control* thread = new Thread_control(ic, kobuki_manager);
         thread->run();

--- a/src/drivers/pclRGBDServer/CMakeLists.txt
+++ b/src/drivers/pclRGBDServer/CMakeLists.txt
@@ -7,10 +7,14 @@ if(pcl_openni)
         ${INTERFACES_CPP_DIR}
         ${LIBS_DIR}/
         ${CMAKE_CURRENT_SOURCE_DIR}
+    	${easyiceconfig_INCLUDE_DIRS}
         /usr/include/vtk-5.8
     )
 
-    link_directories(${pcl_LIBRARIES})
+    link_directories(
+	${pcl_LIBRARIES}
+	${easyiceconfig_LIBRARY_DIRS}
+    )
     include_directories(${pcl_INCLUDE_DIR})
 
     add_executable (pclRGBDServer  ${SOURCE_FILES})
@@ -25,6 +29,7 @@ if(pcl_openni)
       colorspacesmm
       ${openni_LIBRARIES}
       ${Boost_LIBRARIES}
+      ${easyiceconfig_LIBRARIES}
     )
 
 endif()

--- a/src/drivers/pclRGBDServer/kinectServer.cpp
+++ b/src/drivers/pclRGBDServer/kinectServer.cpp
@@ -4,6 +4,8 @@
 #include <Ice/Ice.h>
 #include <IceUtil/IceUtil.h>
 
+#include "easyiceconfig/EasyIce.h" 
+
 #include <jderobot/pointcloud.h>
 #include <jderobot/camera.h>
 
@@ -210,7 +212,7 @@ int main(int argc, char** argv)
     Ice::PropertiesPtr prop;
     try {
         //-----------------ICE----------------//
-        ic = Ice::initialize(argc, argv);
+        ic = EasyIce::initialize(argc, argv);
 
         Ice::PropertiesPtr prop = ic->getProperties();
 			

--- a/src/libs/easyiceconfig_cpp/src/loader.cpp
+++ b/src/libs/easyiceconfig_cpp/src/loader.cpp
@@ -65,8 +65,11 @@ initializeProperties(Ice::StringSeq args, Ice::PropertiesPtr properties){
     if (!iceconfigs.empty()){
         for (std::string iceconfig : std::split(iceconfigs, ","))
             loadIceConfig(iceconfig, properties);
+	properties->parseCommandLineOptions("", args);
+    }else if (args.size() > 1){
+        loadIceConfig(args[1], properties);
     }
-    properties->parseCommandLineOptions("", args);
+    
 
     return properties;
 }

--- a/src/libs/easyiceconfig_py/easyiceconfig/easyiceconfig.py
+++ b/src/libs/easyiceconfig_py/easyiceconfig/easyiceconfig.py
@@ -62,8 +62,9 @@ def initializeProperties(args, properties = Ice.createProperties()):
     if (iceconfigfiles):
         for iceconfig in iceconfigfiles.split(","):
             loadIceConfig(iceconfig, properties)
-
-    properties.parseCommandLineOptions("", args)
+        properties.parseCommandLineOptions("", args)
+    elif (len(args) > 1):
+        loadIceConfig(args[1], properties)
 
     return properties
 

--- a/src/tools/namingService/CMakeLists.txt
+++ b/src/tools/namingService/CMakeLists.txt
@@ -6,7 +6,12 @@ add_definitions(-DGLADE_DIR="${gladedir}")
 include_directories(
     ${INTERFACES_CPP_DIR}
     ${LIBS_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}    
+    ${CMAKE_CURRENT_SOURCE_DIR}   
+    ${easyiceconfig_INCLUDE_DIRS} 
+)
+
+link_directories(
+	${easyiceconfig_LIBRARY_DIRS}
 )
 
 add_executable (namingService ${SOURCE_FILES})
@@ -15,7 +20,8 @@ TARGET_LINK_LIBRARIES(namingService
     ${CMAKE_THREAD_LIBS_INIT}
     ${gsl_LIBRARIES}    
     ${ZeroCIce_LIBRARIES}
-    ${Boost_LIBRARIES}    
+    ${Boost_LIBRARIES}  
+    ${easyiceconfig_LIBRARIES}   
     JderobotInterfaces
     logger
 )

--- a/src/tools/namingService/main.cpp
+++ b/src/tools/namingService/main.cpp
@@ -22,6 +22,8 @@
 #include <Ice/Ice.h>
 #include <IceUtil/IceUtil.h>
 
+#include "easyiceconfig/EasyIce.h" 
+
 #include "pthread.h"
 #include <signal.h>
 #include <log/Logger.h>
@@ -59,7 +61,7 @@ int main(int argc, char** argv){
 	pthread_attr_init(&attr);
 	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	try{
-		ic = Ice::initialize(argc,argv);
+		ic = EasyIce::initialize(argc,argv);
 		prop = ic->getProperties();
 	}catch (const Ice::Exception& ex) {
 		std::cerr << ex << std::endl;

--- a/src/tools/recorder2/CMakeLists.txt
+++ b/src/tools/recorder2/CMakeLists.txt
@@ -13,10 +13,12 @@ include_directories(
     ${libglademm_INCLUDE_DIRS}
     ${gtkglextmm_INCLUDE_DIRS}
     ${resourcelocator_INCLUDE_DIRS}
+    ${easyiceconfig_INCLUDE_DIRS}
 )
 
 link_directories(
 	${resourcelocator_LIBRARY_DIRS}
+	${easyiceconfig_LIBRARY_DIRS}
 )
 
 add_executable (recorder2
@@ -36,6 +38,7 @@ TARGET_LINK_LIBRARIES(recorder2
     ${gsl_LIBRARIES}
     ${ZeroCIce_LIBRARIES}
     ${Boost_LIBRARIES}
+    ${easyiceconfig_LIBRARIES} 
     colorspacesmm
     JderobotInterfaces
     jderobotutil

--- a/src/tools/recorder2/recorder2.cpp
+++ b/src/tools/recorder2/recorder2.cpp
@@ -31,6 +31,7 @@
 #include "poolWriteLasers.h"
 #include "poolWritePointCloud.h"
 #include "poolWriteEncoders.h"
+#include "easyiceconfig/EasyIce.h" 
 
 bool recording=false;
 struct timeval inicio;
@@ -352,7 +353,7 @@ int main(int argc, char** argv){
    
 		Ice::PropertiesPtr prop;
 
-		ic = Ice::initialize(argc,argv);
+		ic = EasyIce::initialize(argc,argv);
 
 		prop = ic->getProperties();
 

--- a/src/tools/visualHFSM/generate.cpp
+++ b/src/tools/visualHFSM/generate.cpp
@@ -121,6 +121,7 @@ void Generate::generateHeaders () {
 void Generate::generateGenericHeaders () {
 	this->fs << "#include <Ice/Ice.h>" << std::endl;
 	this->fs << "#include <IceUtil/IceUtil.h>" << std::endl;
+	this->fs << "#include <easyiceconfig/EasyIce.h>" << std::endl;
 	this->fs << "#include <jderobot/visualHFSM/automatagui.h>" << std::endl;
 	this->fs << std::endl;
 	for ( std::list<std::string>::iterator listLibsIterator = this->listLibraries.begin();
@@ -548,7 +549,7 @@ void Generate::generateMain () {
 	this->fs << "\tIce::CommunicatorPtr ic;" << std::endl;
 	this->fs << std::endl;
 	this->fs << "\ttry {" << std::endl;
-	this->fs << "\t\tic = Ice::initialize(argc, argv);" << std::endl;
+	this->fs << "\t\tic = EasyIce::initialize(argc, argv);" << std::endl;
 	this->fs << "\t\treadArgs(&argc, argv);\n" << std::endl;
 	this->fs << std::endl;
 
@@ -665,13 +666,14 @@ void Generate::generateCmake () {
 	this->fs << "include_directories (" << std::endl;
 	this->fs << "\t/usr/local/include/jderobot" << std::endl;
 	this->fs << "\t${INTERFACES_CPP_DIR}" << std::endl;
+	this->fs << "\t${easyiceconfig_INCLUDE_DIRS}" << std::endl;
 	this->fs << "\t${LIBS_DIR}" << std::endl;
 	this->fs << "\t${CMAKE_CURRENT_SOURCE_DIR}" << std::endl;
 	this->fs << "\t${GTKMM_INCLUDE_DIRS}" << std::endl;
 	this->fs << "\t${goocanvasmm_INCLUDE_DIRS}" << std::endl;
 	this->fs << ")" << std::endl;
 	this->fs << std::endl;
-	this->fs << "link_directories(${GTKMM_LIBRARY_DIRS})" << std::endl;
+	this->fs << "link_directories(${GTKMM_LIBRARY_DIRS} ${easyiceconfig_LIBRARY_DIRS})" << std::endl;
 	this->fs << std::endl;
 	this->fs << "add_executable ("<< this->execpath << " ${SOURCE_FILES_AUTOMATA})" << std::endl;
 	this->fs << std::endl;
@@ -679,6 +681,7 @@ void Generate::generateCmake () {
 	this->fs << std::endl;
 	this->fs << "TARGET_LINK_LIBRARIES (" << this->execpath << std::endl;
 	this->fs << "\t${GTKMM_LIBRARIES}" << std::endl;
+	this->fs << "\t${easyiceconfig_LIBRARIES}" << std::endl;
 	this->fs << "\t${goocanvasmm_LIBRARIES}" <<std::endl;
 	this->fs << "\t${LIBS_DIR}/jderobot/libJderobotInterfaces.so" << std::endl;
 	this->fs << "\t${LIBS_DIR}/jderobot/libjderobotutil.so" << std::endl;
@@ -707,6 +710,7 @@ void Generate::generateGenericHeaders_py(){
 "#!/usr/bin/python\n\
 # -*- coding: utf-8 -*-\n\n\
 import Ice\n\
+import easyiceconfig as EasyIce\n\
 import sys, signal\n\
 sys.path.append('/usr/local/share/jderobot/python/visualHFSM_py')\n\
 import traceback, threading, time\n\
@@ -1197,7 +1201,7 @@ void Generate::generateSubautomatas_py(){
 void Generate::generateConnectToProxys_py(){
 	this->fs << 
 "	def connectToProxys(self):\n\
-		self.ic = Ice.initialize(sys.argv)\n\n";
+		self.ic = EasyIce.initialize(sys.argv)\n\n";
 
 	boost::format fmt_iConnect( /* %1%: getName() %2%: getInterface() */
 "		# Contact to %1%\n\


### PR DESCRIPTION
This pull request allow us to run JdeRobot components (tools, clients or generated with visualHFSM) with o without Ice.Config flag.

Two forms are accepted:
`cameraserver cameraserver.cfg`
`cameraserver --Ice.Config=cameraserver.cfg`


only it has 3 exceptions, Nao client and server an girafferServer because are deprecated
