### PR TITLE
[Issue #485] Refactor resourcelocator to use CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/src)
 #                 #
 ###################
 
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/interfaces/libJderobotInterfaces.so DESTINATION ${CMAKE_INSTALL_PREFIX}/jderobot COMPONENT core)
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/interfaces/libJderobotInterfaces.so DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/jderobot COMPONENT core)
 
 # Install python files
 FILE(GLOB_RECURSE HEADERS_FILES ${CMAKE_CURRENT_BINARY_DIR}/src/interfaces/python/*py)
@@ -187,7 +187,7 @@ ENDFOREACH(currentBin)
 
 FOREACH (currentBin ${LIST_TOOLS})
     if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/${currentBin}/${currentBin})
-        INSTALL (PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/toolss/${currentBin}/${currentBin} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin OPTIONAL COMPONENT core)
+        INSTALL (PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/${currentBin}/${currentBin} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin OPTIONAL COMPONENT core)
     else()
         INSTALL (PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/src/tools/${currentBin}/${currentBin} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin OPTIONAL COMPONENT core)
     endif()

--- a/src/libs/resourcelocator/CMakeLists.txt
+++ b/src/libs/resourcelocator/CMakeLists.txt
@@ -15,13 +15,20 @@ list(APPEND LIBRARIES)
 
 include_directories(
 	${CMAKE_CURRENT_SOURCE_DIR}/include
+	${CMAKE_CURRENT_BINARY_DIR}/include
+)
+
+configure_file(
+    include/resourcelocator/gladelocator.hpp.in
+    include/resourcelocator/gladelocator.hpp
+    @ONLY
 )
 
 ## Sources
 set(SOURCES
 	include/resourcelocator/stdutils.hpp
 	include/resourcelocator/resourcelocator.hpp
-	include/resourcelocator/gladelocator.hpp
+	${CMAKE_CURRENT_BINARY_DIR}/include/resourcelocator/gladelocator.hpp
 
 	src/resourcelocator.cpp
 )
@@ -34,7 +41,7 @@ target_link_libraries(${binname} ${LIBRARIES})
 ## Options
 set_target_properties(${binname} PROPERTIES COMPILE_FLAGS "-Wall -Wextra")
 
-set(${binname}_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include" CACHE PATH "Find(${binname})")
+set(${binname}_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_BINARY_DIR}/include" CACHE PATH "Find(${binname})")
 set(${binname}_LIBRARY_DIRS "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "Find(${binname})")
 set(${binname}_LIBRARIES "${binname}" CACHE STRINGS "Find(${binname})")
 

--- a/src/libs/resourcelocator/include/resourcelocator/gladelocator.hpp.in
+++ b/src/libs/resourcelocator/include/resourcelocator/gladelocator.hpp.in
@@ -29,7 +29,7 @@ namespace resourcelocator {
 
 std::string
 inline findGladeFile(const std::string filename)
-	{ return findFile(filename, "GLADE_PATH", "/usr/local/share/jderobot/glade"); }
+	{ return findFile(filename, "GLADE_PATH", "@CMAKE_INSTALL_PREFIX@/share/jderobot/glade"); }
 
 
 }//NS


### PR DESCRIPTION
This PR should fix the issue #485 **only** for resourcelocator.

Note this PR is intended to be applied only if PR #530 is accepted, please check it first.