### PR TITLE
[Issues #419 #420] Support for Windows

### DIFF
--- a/src/libs/easyiceconfig_py/easyiceconfig/hardcodedpaths.py.in
+++ b/src/libs/easyiceconfig_py/easyiceconfig/hardcodedpaths.py.in
@@ -18,21 +18,26 @@
 #
 __author__ = 'varribas'
 
-
-# JdeRobot main Ice.Config path
-JDEROBOT_PATHS = "@CMAKE_INSTALL_PREFIX@/share/jderobot/conf"
-
-
-# JdeRobot Gazebo's plugins Ice.Config path
 import os
-JDEROBOT_GAZEBO_PLUGINS_BASE_PATH = '@CMAKE_INSTALL_PREFIX@/share/jderobot/gazebo/plugins'
+import platform
 
-gazebo_plugins = list()
-for dir in os.listdir(JDEROBOT_GAZEBO_PLUGINS_BASE_PATH):
-    plugin_dir = os.path.join(JDEROBOT_GAZEBO_PLUGINS_BASE_PATH, dir)
-    gazebo_plugins.append(plugin_dir)
+if ('Windows')==platform.system():
+    JDEROBOT_PATHS = ""
+    JDEROBOT_GAZEBO_PLUGINS_PATHS = ""
+else:
+    # JdeRobot main Ice.Config path
+    JDEROBOT_PATHS = "@CMAKE_INSTALL_PREFIX@/share/jderobot/conf"
 
-JDEROBOT_GAZEBO_PLUGINS_PATHS = ':'.join(str(x) for x in gazebo_plugins)
+
+    # JdeRobot Gazebo's plugins Ice.Config path
+    JDEROBOT_GAZEBO_PLUGINS_BASE_PATH = '@CMAKE_INSTALL_PREFIX@/share/jderobot/gazebo/plugins'
+
+    gazebo_plugins = list()
+    for dir in os.listdir(JDEROBOT_GAZEBO_PLUGINS_BASE_PATH):
+        plugin_dir = os.path.join(JDEROBOT_GAZEBO_PLUGINS_BASE_PATH, dir)
+        gazebo_plugins.append(plugin_dir)
+
+    JDEROBOT_GAZEBO_PLUGINS_PATHS = ':'.join(str(x) for x in gazebo_plugins)
 
 
 # "Hardcoded" PATHS


### PR DESCRIPTION
This PR prepares to Python clients of Jderobot to Windows.
In Windows we already use Ice 3.6 because it was very difficult to install 3.5 and will soon jump to Ice 3.6

## Instalation in Windows: 

**1. Download Dependences:**

Download python 2.7.12 and install checked env variables (Is posible that you need restart to run the PATH):  
https://www.python.org/ftp/python/2.7.12/python-2.7.12.amd64.msi 
 
Download qt 4.8.7:  
http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-opensource-windows-x86-vs2010-4.8.7.exe 

Download github Desktop:
https://desktop.github.com/
 
update pip: 
<pre>python -m pip install --upgrade pip </pre>
Install deps: 
<pre>pip install numpy zeroc-ice 
pip install http://jderobot.org/store/aitormf/uploads/windows/opencv_python-3.1.0-cp27-cp27m-win_amd64.whl 
pip install http://jderobot.org/store/aitormf/uploads/windows/PyQt4-4.11.4-cp27-none-win_amd64.whl 
pip install http://jderobot.org/store/aitormf/uploads/windows/PyQwt-5.2.1-cp27-none-win_amd64.whl </pre>
**2.a Install JdeRobot Python (by Pip):**
<pre>pip install  http://jderobot.org/store/aitormf/uploads/windows/JdeRobot-0.1.0-py2-none-any.whl </pre>

**2.b  Install JdeRobot Python (by source):**
With git Shell clone the repository as in Linux. then copy easyiceconfig and parallelIce Python libs to c:\python27\Lib
Later go to Jderobot\src\interfaces\ slice \jderobot and create  dest directory (in CMD):
<pre>mkdir dest</pre>
create Ice interfaces for Python:
<pre>for /f %f in ('dir /b .\*.ice')do slice2py -I.. --all --output-dir dest %f</pre>

copy the contents of dest to c:\python27\Lib

To test it the best is use TeachingRobotics

**3. Download TeachingRobotics**
With git Shell clone the repository as in Linux and run the exercices with CMD o powershell

## Using Docker for gazebo

1. Download docker: [http://www.docker.com/products/docker](http://www.docker.com/products/docker)

2. Donwload Kitematic of docker

3. Download the image [aitormf/jderobot:gzweb](https://hub.docker.com/r/aitormf/jderobot/tags/)

4. To run the docker and a exercice look this video:

[![Introrob py in Windows ](http://img.youtube.com/vi/Pz-2lVtZCqQ/0.jpg)](http://www.youtube.com/watch?v=Pz-2lVtZCqQ)