### PR TITLE
[issue #562] Updated CMakeLists of various libs

### DIFF
--- a/src/libs/depthLib/CMakeLists.txt
+++ b/src/libs/depthLib/CMakeLists.txt
@@ -15,7 +15,7 @@ TARGET_LINK_LIBRARIES(depthLibshare ${Boost_LIBRARIES} ${ZeroCIce_LIBRARIES} ${O
 set_target_properties(depthLibshare PROPERTIES OUTPUT_NAME depthLib)
 
 ### Install
-install(TARGETS depthLib
+install(TARGETS depthLib depthLibshare
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/jderobot
     COMPONENT core
 )

--- a/src/libs/easyiceconfig_cpp/include/easyiceconfig/stdutils.hpp
+++ b/src/libs/easyiceconfig_cpp/include/easyiceconfig/stdutils.hpp
@@ -59,7 +59,7 @@ namespace std {
 inline
 bool fileexists(std::string filepath){
 	ifstream ifile(filepath.c_str(), ios_base::in);
-	return ifile;
+	return ifile.is_open();
 }
 }//NS
 

--- a/src/libs/fuzzylib/CMakeLists.txt
+++ b/src/libs/fuzzylib/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library (fuzzyshare SHARED fuzzylib.c)
 set_target_properties(fuzzyshare PROPERTIES OUTPUT_NAME fuzzylib)
 
 ### Install
-install(TARGETS fuzzylib
+install(TARGETS fuzzylib fuzzyshare
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/jderobot
     COMPONENT core
 )

--- a/src/libs/geometry/CMakeLists.txt
+++ b/src/libs/geometry/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Boost COMPONENTS system filesystem REQUIRED)
 
 target_link_libraries(geometry tinyxml GLU ${OpenCV_LIBRARIES} ${OpenCVGUI_LIBRARIES} ${Boost_LIBRARIES})
 
-SET_PROPERTY(TARGET geometry PROPERTY SOVERSION 1.0)
+#SET_PROPERTY(TARGET geometry PROPERTY SOVERSION 1.0)
  
 #ADD_LIBRARY(geometry_static STATIC ${SRC_FILES})
 

--- a/src/libs/jderobotHandlers/CMakeLists.txt
+++ b/src/libs/jderobotHandlers/CMakeLists.txt
@@ -17,7 +17,7 @@ TARGET_LINK_LIBRARIES(jderobotHandlersshare ${Boost_LIBRARIES} ${Ice_LIBRARIES})
 set_target_properties(jderobotHandlersshare PROPERTIES OUTPUT_NAME jderobotHandlers)
 
 ### Install
-install(TARGETS jderobotHandlers
+install(TARGETS jderobotHandlers jderobotHandlersshare
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/jderobot
     COMPONENT core
 )

--- a/src/libs/jderobotViewer/CMakeLists.txt
+++ b/src/libs/jderobotViewer/CMakeLists.txt
@@ -17,7 +17,7 @@ if (with_pcl)
     set_target_properties(jderobotViewerShare PROPERTIES OUTPUT_NAME jderobotViewer)
 
     ### Install
-    install(TARGETS jderobotViewer
+    install(TARGETS jderobotViewer jderobotViewerShare
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/jderobot
         COMPONENT core
 )

--- a/src/libs/jderobotutil/CMakeLists.txt
+++ b/src/libs/jderobotutil/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library (jderobotutilshare SHARED jderobotutil.h observer.cpp observer.h par
 set_target_properties(jderobotutilshare PROPERTIES OUTPUT_NAME jderobotutil)
 
 ### Install
-install(TARGETS jderobotutil
+install(TARGETS jderobotutil jderobotutilshare
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/jderobot
     COMPONENT core
 )

--- a/src/libs/log/CMakeLists.txt
+++ b/src/libs/log/CMakeLists.txt
@@ -22,7 +22,7 @@ ADD_LIBRARY(logger SHARED ${SRC_FILES})
 
 target_link_libraries(logger ${Boost_LIBRARIES})
 
-SET_PROPERTY(TARGET logger PROPERTY SOVERSION 0.1.0)
+#SET_PROPERTY(TARGET logger PROPERTY SOVERSION 0.1.0)
 
 ### Install
 install(TARGETS logger

--- a/src/libs/ns/CMakeLists.txt
+++ b/src/libs/ns/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(ns
 	${ZeroCIce_LIBRARIES}
 )
 
-SET_PROPERTY(TARGET ns PROPERTY SOVERSION 0.1.0)
+#SET_PROPERTY(TARGET ns PROPERTY SOVERSION 0.1.0)
  
 ### Install
 install(TARGETS ns

--- a/src/libs/parallelIce/CMakeLists.txt
+++ b/src/libs/parallelIce/CMakeLists.txt
@@ -15,7 +15,7 @@ TARGET_LINK_LIBRARIES(parallelIceshare colorspacesmm logger ${Boost_LIBRARIES} $
 set_target_properties(parallelIceshare PROPERTIES OUTPUT_NAME parallelIce)
 
 ### Install
-install(TARGETS parallelIce
+install(TARGETS parallelIce parallelIceshare
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/jderobot
     COMPONENT core
 )

--- a/src/libs/pioneer/CMakeLists.txt
+++ b/src/libs/pioneer/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library (pioneershare SHARED pioneer.c pioneer.h)
 set_target_properties(pioneershare PROPERTIES OUTPUT_NAME pioneer)
 
 ### Install
-install(TARGETS pioneer
+install(TARGETS pioneer pioneershare
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/jderobot
     COMPONENT core
 )

--- a/src/libs/resourcelocator/include/resourcelocator/stdutils.hpp
+++ b/src/libs/resourcelocator/include/resourcelocator/stdutils.hpp
@@ -65,7 +65,7 @@ namespace std {
 inline
 bool fileexists(std::string filepath){
 	ifstream ifile(filepath.c_str(), ios_base::in);
-	return ifile;
+	return ifile.is_open();
 }
 }//NS
 

--- a/src/libs/xmlParser/CMakeLists.txt
+++ b/src/libs/xmlParser/CMakeLists.txt
@@ -14,7 +14,7 @@ TARGET_LINK_LIBRARIES(xmlParsershare ${Boost_LIBRARIES} ${libxmlpp_LIBRARIES} )
 set_target_properties(xmlParsershare PROPERTIES OUTPUT_NAME xmlParser)
 
 ### Install
-install(TARGETS xmlParser
+install(TARGETS xmlParser xmlParsershare
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/jderobot
     COMPONENT core
 )


### PR DESCRIPTION
Solved problem installing dynamic libraries with Cmake 3.5. 

IMPORTANT NOTE: some libs versions have been removed due to cpack doesn't link some of them when building the package. Please @chanfr check this. 