### PR TITLE
[issue #599] Updated Dockerfiles to use Jderobot 5.4.1

### DIFF
--- a/scripts/docker/gazebo/gzserver/Dockerfile
+++ b/scripts/docker/gazebo/gzserver/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:xenial
+MAINTAINER Aitor Martínez Fernández+aitor-martinez.fernandez@gmail.ocm
+
+# setup keys
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+
+# setup sources.list
+RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main" > /etc/apt/sources.list.d/gazebo-latest.list
+
+# install gazebo packages
+RUN apt-get update && apt-get install -q -y \
+    gazebo7\
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+EXPOSE 11345
+
+# setup entrypoint
+COPY ./gzserver_entrypoint.sh /
+
+ENTRYPOINT ["/gzserver_entrypoint.sh"]
+CMD ["gzserver"]

--- a/scripts/docker/gazebo/gzserver/gzserver_entrypoint.sh
+++ b/scripts/docker/gazebo/gzserver/gzserver_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup gazebo environment
+source "/usr/share/gazebo/setup.sh"
+exec "$@"

--- a/scripts/docker/jderobot/base/Dockerfile
+++ b/scripts/docker/jderobot/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM gazebo:libgazebo7
+FROM jderobot/gzserver
 
 MAINTAINER Aitor Martinez+aitor.martinez.fernandez@gmail.com
 
@@ -6,120 +6,20 @@ LABEL Usage.run="docker run -itP --rm jderobot/jderobot:base world [world_name]"
 LABEL Usage.listWorlds="docker run --rm jderobot/jderobot:base lsworld"
 LABEL Usage.enter="docker run -itP --rm jderobot/jderobot:base"
 
-#RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list'
-#RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
-RUN sh -c 'echo deb http://ppa.launchpad.net/v-launchpad-jochen-sprickerhof-de/pcl/ubuntu trusty main > /etc/apt/sources.list.d/v-launchpad-jochen-sprickerhof-de-pcl-trusty.list'
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D51148574AAB18C259B43628D8A3751519274DEF
-
-RUN sh -c 'echo deb http://zeroc.com/download/apt/ubuntu14.04 stable main > /etc/apt/sources.list.d/zeroc.list'
+RUN sh -c 'echo deb http://zeroc.com/download/apt/ubuntu16.04 stable main > /etc/apt/sources.list.d/zeroc.list'
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 5E6DA83306132997
 
-RUN apt-get update && apt-get -y  install \
-	build-essential \ 
-	libtinyxml-dev \ 
-	libtbb-dev \
-	libxml2-dev \
-	libqt4-dev \
-	pkg-config \ 
-	libprotoc-dev \ 
-	libfreeimage-dev \ 
-	libprotobuf-dev \ 
-	protobuf-compiler \ 
-	libboost-all-dev \ 
-	freeglut3-dev \ 
-	cmake \ 
-	libtar-dev \ 
-	libcurl4-openssl-dev \ 
-	libcegui-mk2-dev \ 
-	libswscale-dev \ 
-	libavformat-dev \ 
-	libavcodec-dev \ 
-	git \
-	&& rm -rf /var/lib/apt/lists/*
+RUN sh -c 'echo "deb http://jderobot.org/apt xenial main" > /etc/apt/sources.list.d/jderobot.list'
 
-RUN apt-get update && apt-get -y install \ 
-	libxml++2.6-2 \ 
-	libxml++2.6-dev \ 
-	libvtk5.8 \ 
-	libvtk5-dev \
-	&& rm -rf /var/lib/apt/lists/*
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B0E7F58E82C8091DF945A0453DA08892EE69A25C
 
-# gtk libraries
-RUN apt-get update && apt-get -y install \ 
-	libgtk2.0-0 \ 
-	libgtk2.0-bin \ 
-	libgtk2.0-cil \ 
-	libgtk2.0-common \ 
-	libgtk2.0-dev \ 
-	libgtkgl2.0-1 \
-	&& rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get -y install \ 
-	libgtkgl2.0-dev \ 
-	libgtkglext1 \ 
-	libgtkglext1-dev \ 
-	libglademm-2.4-dev \ 
-	libgtkmm-2.4-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
-	
-RUN apt-get update && apt-get -y install \
-	libgnomecanvas2-0 \ 
-	libgnomecanvas2-dev \ 
-	libgnomecanvasmm-2.6-dev \
-	&& rm -rf /var/lib/apt/lists/*
-	
-RUN apt-get update && apt-get -y install \ 
-	libgnomecanvasmm-2.6-1c2a \ 
-	libgtkglextmm-x11-1.2-0 \ 
-	libgtkglextmm-x11-1.2-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
-# GSL libraries
-RUN apt-get update && apt-get -y install \ 
-	libgsl0ldbl \ 
-	libgsl0-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
-# PCL
-RUN apt-get update \
-	&& apt-get -y install libpcl-all \
-	&& rm -rf /var/lib/apt/lists/*
-
-# Gazebo7
-RUN apt-get update && apt-get -y install \ 
-#	gazebo7 \ 
-#	libgazebo7-dev \ 
-	libopencv-dev \
-	xvfb \
-	&& rm -rf /var/lib/apt/lists/*
-
-
-# install ICE
-RUN apt-get update && apt-get -y install \ 
-	libzeroc-ice3.6 \ 
-	zeroc-ice-utils \ 
-	libzeroc-icestorm3.6 \ 
-	zeroc-ice-slice \ 
-	libzeroc-ice-dev \
-	&& rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get -y install libbz2-dev python-pip && rm -rf /var/lib/apt/lists/*
-
-
-RUN pip install zeroc-ice
 
 # JdeRobot
-
-COPY ./installJderobot.sh /
-
-RUN ./installJderobot.sh
-
-#RUN sh -c 'mv /usr/local/jderobot/* /usr/local/lib/jderobot'
-
-RUN rm -rf /var/lib/apt/lists/*
-RUN rm -rf /git
+RUN apt-get update && apt-get -y  install \
+	jderobot \
+	xvfb \
+	&& rm -rf /var/lib/apt/lists/*
 
 # setup environment JdeRobot
 EXPOSE 8990

--- a/scripts/docker/jderobot/gzweb/Dockerfile
+++ b/scripts/docker/jderobot/gzweb/Dockerfile
@@ -10,8 +10,9 @@ LABEL Usage.enter="docker run --rm jderobot/jderobot:gzweb"
 RUN apt-get update && apt-get install -q -y \
     build-essential \
     cmake \
+    libgazebo7-dev \
     imagemagick \
-    libboost-all-dev \
+    libboost-dev \
     libgts-dev \
     libjansson-dev \
     libtinyxml-dev \

--- a/scripts/docker/jderobot/gzweb/installGzweb.sh
+++ b/scripts/docker/jderobot/gzweb/installGzweb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd ~/gzweb
-hg up jderobot
+hg up jderobot2
 source /usr/local/share/jderobot/gazebo/gazebo-setup.sh
 Xvfb -shmem -screen 0 1280x1024x24 &
 export DISPLAY=:0


### PR DESCRIPTION
Updated Dockerfiles to use Jderobot 5.4.1.

- I've had to create a Docker for **gazebo7 with Ubuntu Xenial** (16.04) because before we used oficial gazebo7 docker but this is with Trusty (14.04).
- **Jderobot:base** not needs compile JdeRobot, now use oficial package
- **Jderobot:gzweb** have been updated from gzweb 1.3 to gzweb 2.0