### PR TITLE
[issue #629] Solved bug in KobukiViewerJS and UavVieweJS

### DIFF
--- a/src/tools/kobukiviewerjs/public/js/api_workers/motors_worker.js
+++ b/src/tools/kobukiviewerjs/public/js/api_workers/motors_worker.js
@@ -4,6 +4,10 @@ var global=self;
 
 // importing required files
 importScripts('../Ice.min.js');
+importScripts('../jderobot/datetime.js');
+importScripts('../jderobot/exceptions.js');
+importScripts('../jderobot/containers.js');
+importScripts('../jderobot/common.js');
 importScripts('../jderobot/motors.js');
 
 

--- a/src/tools/kobukiviewerjs/public/js/api_workers/pose3d_worker.js
+++ b/src/tools/kobukiviewerjs/public/js/api_workers/pose3d_worker.js
@@ -4,6 +4,10 @@ var global=self;
 
 // importing required files
 importScripts('../Ice.min.js');
+importScripts('../jderobot/datetime.js');
+importScripts('../jderobot/exceptions.js');
+importScripts('../jderobot/containers.js');
+importScripts('../jderobot/common.js');
 importScripts('../jderobot/pose3d.js');
 
 

--- a/src/tools/uavviewerjs/public/js/api_workers/pose3d_worker.js
+++ b/src/tools/uavviewerjs/public/js/api_workers/pose3d_worker.js
@@ -4,6 +4,10 @@ var global=self;
 
 // importing required files
 importScripts('../Ice.min.js');
+importScripts('../jderobot/datetime.js');
+importScripts('../jderobot/exceptions.js');
+importScripts('../jderobot/containers.js');
+importScripts('../jderobot/common.js');
 importScripts('../jderobot/pose3d.js');
 
 


### PR DESCRIPTION
The problem was that in the jump from beta version of IceJS to 3.6.3, there are some dependencies of some interfaces that have become obligatories