### PR TITLE
[issue #749] Added launcher to basic_component_py

### DIFF
--- a/src/tools/basic_component_py/CMakeLists.txt
+++ b/src/tools/basic_component_py/CMakeLists.txt
@@ -1,5 +1,18 @@
 
+configure_file(
+    basic_component_py.in
+    basic_component_py
+    @ONLY
+)
+
 ## INSTALL ##
+
+# install Launcher
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/basic_component_py
+    PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
+    DESTINATION bin
+)
 
 # Install .py
 FILE(GLOB_RECURSE HEADERS_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*py)

--- a/src/tools/basic_component_py/basic_component_py.in
+++ b/src/tools/basic_component_py/basic_component_py.in
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python @CMAKE_INSTALL_PREFIX@/share/jderobot/python/basic_component_py/basic_component.py $*


### PR DESCRIPTION
Added launcher to basic_component_py

Now, after installing, you can launch basic_component_py using:

<pre>
basic_component_py basic_component_py.cfg
</pre>

fix #749