### PR TITLE
[issue #750] Added Launcher to uav_viewer_py

### DIFF
--- a/src/tools/uav_viewer_py/CMakeLists.txt
+++ b/src/tools/uav_viewer_py/CMakeLists.txt
@@ -1,6 +1,18 @@
 
+configure_file(
+    uav_viewer_py.in
+    uav_viewer_py
+    @ONLY
+)
 
 ## INSTALL ##
+
+# Install launcher
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/uav_viewer_py
+    PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
+    DESTINATION bin
+)
 
 # Install .py
 FILE(GLOB_RECURSE HEADERS_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*py)

--- a/src/tools/uav_viewer_py/uav_viewer_py.in
+++ b/src/tools/uav_viewer_py/uav_viewer_py.in
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python @CMAKE_INSTALL_PREFIX@/share/jderobot/python/uav_viewer_py/uav_viewer.py $*


### PR DESCRIPTION
 Added Launcher to uav_viewer_py

Now, after installing, you can launch uav_viewer_py using:

<pre>
uav_viewer_py uav_viewer_py.cfg
</pre>

fix #750