### PR TITLE
Lights are needed in the 3D_reconstruction world #853

### DIFF
--- a/src/drivers/gazeboserver/worlds/reconstruccion3D.world
+++ b/src/drivers/gazeboserver/worlds/reconstruccion3D.world
@@ -7,7 +7,13 @@
     <include>
         <uri>model://sun</uri>
     </include>
-
+    <light name='point_light1' type='point'>
+      <pose frame=''>2.3 -0.25 1 0 0 0</pose>
+    </light>
+    <light name='point_light2' type='point'>
+      <pose frame=''>2.3 0.25 1 0 0 0</pose>
+    </light>
+    
     <!-- Pioneer2dx model -->
     <include>
       <uri>model://turtlebotJde2cam</uri>


### PR DESCRIPTION
The objects in the images from the robot cameras are too dark and so, the image processing to estimate 3D data is not feasible.
