### PR TITLE
[issue #845] Pantilt_teleop now use jderobotcomm for camera

### DIFF
--- a/src/tools/pantilt_teleop_py/gui/cameraWidget.py
+++ b/src/tools/pantilt_teleop_py/gui/cameraWidget.py
@@ -42,7 +42,7 @@ class CameraWidget(QtWidgets.QWidget):
     def updateImage(self):
 
         if (self.winParent.getCamera()):
-            img = self.winParent.getCamera().getImage()
+            img = self.winParent.getCamera().getImage().data
             if img is not None:
                 image = QImage(img.data, img.shape[1], img.shape[0],
                                      img.shape[1] * img.shape[2], QImage.Format_RGB888)

--- a/src/tools/pantilt_teleop_py/pantilt_teleop.cfg
+++ b/src/tools/pantilt_teleop_py/pantilt_teleop.cfg
@@ -1,3 +1,10 @@
-UavViewer.Camera.Proxy  = ardrone_camera:default -h localhost -p 9999
 PanTiltTeleop.PTMotors.Proxy  = PanTilt:default -h localhost -p 9977
+
+############ Camera #######################
+# 0 -> Deactivate, 1 -> Ice , 2 -> ROS
+PanTiltTeleop.Camera.Server=2
+PanTiltTeleop.Camera.Proxy=cameraA:default -h localhost -p 9999
+PanTiltTeleop.Camera.Format=RGB8
+PanTiltTeleop.Camera.Topic=/usb_cam/image_raw
+PanTiltTeleop.Camera.Name=pantilt_teleop_pyCamera
 

--- a/src/tools/pantilt_teleop_py/pantilt_teleop.py
+++ b/src/tools/pantilt_teleop_py/pantilt_teleop.py
@@ -21,7 +21,7 @@
 
 import sys
 
-from parallelIce.cameraClient import CameraClient
+import jderobotComm as comm
 from parallelIce.ptMotors import PTMotorsClient
 from gui.threadGUI import ThreadGUI
 from gui.GUI import MainWindow
@@ -35,7 +35,10 @@ signal.signal(signal.SIGINT, signal.SIG_DFL)
 if __name__ == '__main__':
     ic = EasyIce.initialize(sys.argv)
 
-    camera = CameraClient(ic, "PanTiltTeleop.Camera", True)
+    #starting comm
+    ic, node = comm.init(ic)
+
+    camera = comm.getCameraClient(ic, "PanTiltTeleop.Camera")
     motors = PTMotorsClient(ic,"PanTiltTeleop.PTMotors", True)
 
     app = QApplication(sys.argv)


### PR DESCRIPTION
Pantilt_teleop now use jderobotcomm instead of parallelce for camera interface.

Finally, as Evi_cam uses v4l as a driver I have decided to use the Ros Usb_cam driver to serve the images instead of make a server.

[video](https://www.youtube.com/watch?v=wYvz57oRFU0)

