### PR TITLE
[Issue  #887 and #888]: resolving cameraview_py installation and BGR color space

### DIFF
--- a/src/tools/cameraview_py/CMakeLists.txt
+++ b/src/tools/cameraview_py/CMakeLists.txt
@@ -1,0 +1,23 @@
+configure_file(
+    cameraview_py.in
+    cameraview_py
+    @ONLY
+)
+
+## INSTALL ##
+
+# install Launcher
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/cameraview_py
+    PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
+    DESTINATION bin
+)
+
+# Install .py
+FILE(GLOB_RECURSE HEADERS_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*py)
+FOREACH(header ${HEADERS_FILES})
+	INSTALL(FILES ${header} DESTINATION share/jderobot/python/cameraview_py/ COMPONENT tools)
+ENDFOREACH(header)
+
+# Install resources
+INSTALL (FILES ${CMAKE_CURRENT_SOURCE_DIR}/cameraview_py.cfg DESTINATION ${CMAKE_INSTALL_PREFIX}/share/jderobot/conf)

--- a/src/tools/cameraview_py/cameraview.py
+++ b/src/tools/cameraview_py/cameraview.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         image = np.zeros((imageData_h, imageData_w, 3), np.uint8)
         image = np.frombuffer(imageData.pixelData, dtype=np.uint8)
         image.shape = imageData_h, imageData_w, 3
-        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
         cv2.imshow("Image", image)
         key=cv2.waitKey(30)
 

--- a/src/tools/cameraview_py/cameraview.py
+++ b/src/tools/cameraview_py/cameraview.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
         image = np.zeros((imageData_h, imageData_w, 3), np.uint8)
         image = np.frombuffer(imageData.pixelData, dtype=np.uint8)
         image.shape = imageData_h, imageData_w, 3
+        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         cv2.imshow("Image", image)
         key=cv2.waitKey(30)
 

--- a/src/tools/cameraview_py/cameraview_py.cfg
+++ b/src/tools/cameraview_py/cameraview_py.cfg
@@ -1,1 +1,1 @@
-Camera.Proxy  = cameraA:default -h 192.168.1.16 -p 9999
+Camera.Proxy = cameraA:default -h localhost -p 9999

--- a/src/tools/cameraview_py/cameraview_py.in
+++ b/src/tools/cameraview_py/cameraview_py.in
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python @CMAKE_INSTALL_PREFIX@/share/jderobot/python/cameraview_py/cameraview.py $*


### PR DESCRIPTION
The following code changes were done for #887 and #888: 

- added a file cameraview.in which contains the cmake install prefix as follows: 
`#!/bin/bash`
`python @CMAKE_INSTALL_PREFIX@/share/jderobot/python/cameraview_py/cameraview.py $*`
- using the CMakeLists.txt of basic_component_py, I wrote a CMakeLists.txt file for cameraview_py
- the IP address contained in the file cameraview_py.cfg was changed to: 
`Camera.Proxy = cameraA:default -h 192.168.1.16 -p 9999`
- after successfully installing cameraview_py, I started cameraserver and ran camerview_py. I noticed that the colour space used by camerview_py was BGR instead of RGB. To resolve this I have added the following line in the file cameraview.py: 
`image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)`