### PR TITLE
use interface name as the header mapping key fixes #923

### DIFF
--- a/src/tools/visualStates_py/gui/cppgenerator.py
+++ b/src/tools/visualStates_py/gui/cppgenerator.py
@@ -128,12 +128,10 @@ class CppGenerator(Generator):
 
         # generate interface headers
         for cfg in self.config.getInterfaces():
-            if len(cfg['proxyName']) == 0:
-                cfg['proxyName'] = cfg['interface']
             headers.append('#include <jderobot/config/config.h>\n')
             headers.append('#include <jderobot/comm/communicator.hpp>\n')
             headers.append('#include <jderobot/comm/')
-            headers.append(self.interfaceHeaders[cfg['proxyName']].strip('\n'))
+            headers.append(self.interfaceHeaders[cfg['interface']].strip('\n'))
             headers.append('.hpp>\n')
 
         headers.append('\n')


### PR DESCRIPTION
Uses interface name as the header mapping during cpp code generation and solves #923