### PR TITLE
[#967 & #952] yaml-cpp required and bug in scratch2jderobot

### DIFF
--- a/Deps/yaml-cpp/CMakeLists.txt
+++ b/Deps/yaml-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(yaml-cpp)
+find_package(yaml-cpp REQUIRED)
 
 if (YAML_CPP_INCLUDE_DIR)
 	message("***YAML-CPP FOUND: ${YAML_CPP_INCLUDE_DIR}")

--- a/src/tools/scratch2jderobot/CMakeLists.txt
+++ b/src/tools/scratch2jderobot/CMakeLists.txt
@@ -1,4 +1,5 @@
 IF (ENABLE_ROS)
+    project(scratch2jderobot)
 	## Find catkin macros and libraries
 	find_package(catkin REQUIRED COMPONENTS
 	    rospy


### PR DESCRIPTION
added required clause to yaml-cpp and solved bug in scratch2jderobot  CMakeLists