### PR TITLE
[tools] [visualstates] create new state machine does not remove items

### DIFF
--- a/src/tools/visualStates_py/gui/treemodel.py
+++ b/src/tools/visualStates_py/gui/treemodel.py
@@ -124,12 +124,12 @@ class TreeModel(QAbstractItemModel):
         if parent is None:
             parent = self.rootNode
         childToBeRemoved = None
-        for s in parent.getChildren(self.rootNode):
+        for s in parent.getChildren():
             if s.id == state.id:
                 childToBeRemoved = s
                 break
 
-        if childToBeRemoved != None:
+        if childToBeRemoved is not None:
             # print('remove child.id:' + str(childToBeRemoved.id))
             parent.removeChild(childToBeRemoved)
             self.layoutChanged.emit()

--- a/src/tools/visualStates_py/gui/visualstates.py
+++ b/src/tools/visualStates_py/gui/visualstates.py
@@ -181,6 +181,8 @@ class VisualStates(QMainWindow):
 
     def newAction(self):
         self.automataScene.clearScene()
+        self.treeModel.removeAll()
+
         # create new root state
         self.rootState = State(0, 'root', True)
         self.automataScene.setActiveState(self.rootState)


### PR DESCRIPTION
Fixes the bug that does not remove states from tree view when new state machine is created. Also, it fixes the bug that occurs when trying to remove a state.