### PR TITLE
issue #1121 Modify the ice interface of JdeRobot to work with 3DViewer-web

### DIFF
--- a/src/interfaces/slice/jderobot/visualization.ice
+++ b/src/interfaces/slice/jderobot/visualization.ice
@@ -32,14 +32,22 @@ module jderobot{
 	    float b;
 	};
 
-
+	struct RGBSegment{
+	    Segment seg;
+	    Color c;
+	};
+	
+	sequence<RGBPoint> bufferPoint; 
+	sequence<RGBSegment> bufferSegment;
   /**
    * Interface to the Visualization interaction.
    */
 	interface Visualization
 	{
         void drawSegment(Segment seg, Color c);
+	bufferSegment getSegment();
         void drawPoint(Point p, Color c);
+	bufferPoint getPoints();
         void clearAll();
 	};
 


### PR DESCRIPTION
Modification in the JdeRobot interface, visualization.ice, to be able to connect the new viewer with the 3Drecontrunction practice of Academy.

A new RGBSegments class (segment + color) and two sequences have been created to create the point and segment sending buffers. In addition, two new functions that return these buffers are added.