### PR TITLE
Updated Nurburgrin world with light

### DIFF
--- a/assets/gazebo/worlds/nurburgrinLineROS.world
+++ b/assets/gazebo/worlds/nurburgrinLineROS.world
@@ -6,11 +6,63 @@
     </include>
     <include>
       <uri>model://nurburgrinLine</uri>
-      <pose>0 0 0 0 0 o</pose>
+      <pose>0 0 0 0 0 0</pose>
     </include>
     <include>
-      <uri>model://f1_redbull</uri>
+      <uri>model://f1_renault</uri>
       <pose>-59.25 28.6 0 0 0 -0.55</pose>
     </include>
+    <light name='light1' type='directional'>
+      <pose frame=''>-36.0434 5.35536 1 0 -0 0</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0.1 0.1 -0.9</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.5</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>1</cast_shadows>
+    </light>
+    <light name='light2' type='directional'>
+      <pose frame=''>-33.8751 1.73502 1 0 -0 0</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0.1 0.1 -0.9</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.5</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>1</cast_shadows>
+    </light>
+    <light name='light3' type='directional'>
+      <pose frame=''>-30.1579 4.34083 1 0 -0 0</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0.1 0.1 -0.9</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.5</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>1</cast_shadows>
+    </light>
+    <light name='light4' type='directional'>
+      <pose frame=''>-39.5494 4.16567 1 0 -0 0</pose>
+      <diffuse>0.5 0.5 0.5 1</diffuse>
+      <specular>0.1 0.1 0.1 1</specular>
+      <direction>0.1 0.1 -0.9</direction>
+      <attenuation>
+        <range>20</range>
+        <constant>0.5</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <cast_shadows>1</cast_shadows>
+    </light>
   </world>
 </sdf>


### PR DESCRIPTION
This pull-request add more light and use the f1_renault model in the Nurburgrin circuit. Fixes the #1335 issue.